### PR TITLE
Add captive-browser-dhcpcd-chromium.toml

### DIFF
--- a/captive-browser-dhcpcd-chromium.toml
+++ b/captive-browser-dhcpcd-chromium.toml
@@ -1,0 +1,29 @@
+# browser is the shell (/bin/sh) command executed once the proxy starts.
+# When browser exits, the proxy exits. An extra env var PROXY is available.
+#
+# Here, we use a separate Chrome instance in Incognito mode, so that
+# it can run (and be waited for) alongside the default one, and that
+# it maintains no state across runs. To configure this browser open a
+# normal window in it, settings will be preserved.
+browser = """
+    chromium \
+    --user-data-dir="$HOME/.chromium-captive" \
+    --proxy-server="socks5://$PROXY" \
+    --host-resolver-rules="MAP * ~NOTFOUND , EXCLUDE localhost" \
+    --no-first-run --new-window --incognito \
+    http://example.com
+"""
+
+# dhcp-dns is the shell (/bin/sh) command executed to obtain the DHCP
+# DNS server address. The first match of an IPv4 regex is used.
+# IPv4 only, because let's be real, it's a captive portal.
+#
+# `enp2s0` is your network interface (eth0, wlan0 ...)
+#
+# for this command we have to `grep` because this program takes the first IP from the output
+#
+dhcp-dns = "dhcpcd -U wlan0 | grep domain_name_servers"
+
+# socks5-addr is the listen address for the SOCKS5 proxy server.
+socks5-addr = "localhost:1666"
+


### PR DESCRIPTION
That's for a typical Arch Linux machine, using netctl with the default
dhcpcd (and Chromium from the supported extra repo).