### PR TITLE
cmd/systemd-networkd-dns: add help text

### DIFF
--- a/cmd/systemd-networkd-dns/main.go
+++ b/cmd/systemd-networkd-dns/main.go
@@ -17,9 +17,6 @@ import (
 	"github.com/godbus/dbus"
 )
 
-func init() {
-}
-
 func main() {
 	args := os.Args
 	flag.Usage = func() {

--- a/cmd/systemd-networkd-dns/main.go
+++ b/cmd/systemd-networkd-dns/main.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"net"
@@ -16,11 +17,27 @@ import (
 	"github.com/godbus/dbus"
 )
 
+func init() {
+}
+
 func main() {
 	args := os.Args
+	flag.Usage = func() {
+		fmt.Printf(`usage: %s <interface>
+
+The systemd-networkd-dns command obtains the DHCP DNS server via DBus.
+
+For this to work, you must be running both systemd-networkd and
+systemd-resolved and provide the network interface name for your NIC
+that's connected to the DHCP network.
+`, args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
 	if len(args) < 2 {
-		log.Println("usage:", args[0], "<interface>")
-		log.Fatalln("error: must provide interface name for DHCP-enabled NIC")
+		log.Println("error: must provide interface name for DHCP-enabled NIC")
+		flag.Usage()
+		os.Exit(2)
 	}
 
 	dns, err := getDHCPDNSForInterfaceFromDBus(args[1])


### PR DESCRIPTION
I ran `<program> --help` and it was interpreted as an interface, not
as an instruction to print the help text, so it might be good to fix
that.