### PR TITLE
'bind-device' option to avoid collisions of address space with other interfaces

### DIFF
--- a/captive-browser-arch-chrome.toml
+++ b/captive-browser-arch-chrome.toml
@@ -29,7 +29,7 @@ dhcp-dns = "$(go env GOPATH)/bin/systemd-networkd-dns wlp3s0"
 # socks5-addr is the listen address for the SOCKS5 proxy server.
 socks5-addr = "localhost:1666"
 
-# bind-device is the interface over which DNS requests will be sent.
-# It can be used to avoid address space collisions with other interfaces
-# but it requires CAP_NET_RAW or root priveleges. Disabled by default.
+# bind-device is the interface over which outbound connections (both HTTP
+# and DNS) will be established. It can be used to avoid address space collisions
+# but it requires CAP_NET_RAW or root privileges. Disabled by default.
 #bind-device = "wlan0"

--- a/captive-browser-arch-chrome.toml
+++ b/captive-browser-arch-chrome.toml
@@ -29,7 +29,7 @@ dhcp-dns = "$(go env GOPATH)/bin/systemd-networkd-dns wlp3s0"
 # socks5-addr is the listen address for the SOCKS5 proxy server.
 socks5-addr = "localhost:1666"
 
-# bind to device to avoid address space collisions with other interfaces
-# it requires CAP_NET_RAW or root priveleges
-# empty string disables the option
-bind-device = "wlan0"
+# bind-device is the interface over which DNS requests will be sent.
+# It can be used to avoid address space collisions with other interfaces
+# but it requires CAP_NET_RAW or root priveleges. Disabled by default.
+#bind-device = "wlan0"

--- a/captive-browser-arch-chrome.toml
+++ b/captive-browser-arch-chrome.toml
@@ -29,3 +29,7 @@ dhcp-dns = "$(go env GOPATH)/bin/systemd-networkd-dns wlp3s0"
 # socks5-addr is the listen address for the SOCKS5 proxy server.
 socks5-addr = "localhost:1666"
 
+# bind to device to avoid address space collisions with other interfaces
+# it requires CAP_NET_RAW or root priveleges
+# empty string disables the option
+bind-device = "wlan0"

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
+	"syscall"
 
 	"github.com/BurntSushi/toml"
 	"github.com/armon/go-socks5"
@@ -19,13 +20,13 @@ type UpstreamResolver struct {
 	r *net.Resolver
 }
 
-func NewUpstreamResolver(upstream string) *UpstreamResolver {
+func NewUpstreamResolver(upstream string, dialer *net.Dialer) *UpstreamResolver {
 	return &UpstreamResolver{
 		r: &net.Resolver{
 			PreferGo: true,
 			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
 				// Redirect all Resolver dials to the upstream.
-				return (&net.Dialer{}).DialContext(ctx, network, net.JoinHostPort(upstream, "53"))
+				return dialer.DialContext(ctx, network, net.JoinHostPort(upstream, "53"))
 			},
 		},
 	}
@@ -55,6 +56,7 @@ type Config struct {
 	SOCKS5Addr string `toml:"socks5-addr"`
 	Browser    string
 	DHCP       string `toml:"dhcp-dns"`
+	BindDevice string `toml:"bind-device"`
 }
 
 func main() {
@@ -87,8 +89,25 @@ func main() {
 	}
 	upstream := string(match)
 
+	dialer := &net.Dialer{
+		Control: func(network, address string, c syscall.RawConn) error {
+			c.Control(func(fd uintptr) {
+				if conf.BindDevice != "" {
+					err := syscall.BindToDevice(int(fd), conf.BindDevice)
+					if err != nil {
+						log.Fatalln("BindToDevice", err)
+					}
+				}
+			})
+			return nil
+		},
+	}
+
 	srv, err := socks5.New(&socks5.Config{
-		Resolver: NewUpstreamResolver(upstream),
+		Resolver: NewUpstreamResolver(upstream, dialer),
+		Dial: func(ctx context.Context, net_, addr string) (net.Conn, error) {
+			return dialer.Dial(net_, addr)
+		},
 	})
 	if err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
bind to device to avoid address space collisions of captive portal's addresses (which are often in ```10.x.x.x``` or ```172.{16-31}.x.x``` or ```192.168.x.x```) with other interfaces (VPN, or ```libvirt```, which are likely use addresses from private space as well)

it requires ```CAP_NET_RAW``` or root priveleges

empty string disables the option and allows to use ```captive-browser``` without additional privileges.

Fixes #11