### PR TITLE
Avoid building linux-specific feature (BindToDevice) on other platforms

### DIFF
--- a/bind_device_linux.go
+++ b/bind_device_linux.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"log"
+	"syscall"
+)
+
+func bindToDevice(device string) func(network, address string, c syscall.RawConn) error {
+	return func(network, address string, c syscall.RawConn) error {
+		return c.Control(func(fd uintptr) {
+			err := syscall.BindToDevice(int(fd), device)
+			if err != nil {
+				log.Fatalf("Failed to bind to %q: %s", device, err)
+			}
+		})
+	}
+}

--- a/bind_device_other.go
+++ b/bind_device_other.go
@@ -10,6 +10,6 @@ import (
 
 func bindToDevice(device string) func(network, address string, c syscall.RawConn) error {
 	return func(network, address string, c syscall.RawConn) error {
-		return fmt.Errorf("Device binding not supported on %s", runtime.GOOS)
+		return fmt.Errorf("bind-device not supported on %s", runtime.GOOS)
 	}
 }

--- a/bind_device_other.go
+++ b/bind_device_other.go
@@ -1,0 +1,15 @@
+// +build !linux
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"syscall"
+)
+
+func bindToDevice(device string) func(network, address string, c syscall.RawConn) error {
+	return func(network, address string, c syscall.RawConn) error {
+		return fmt.Errorf("Device binding not supported on %s", runtime.GOOS)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
-	"syscall"
 
 	"github.com/BurntSushi/toml"
 	"github.com/armon/go-socks5"
@@ -91,14 +90,7 @@ func main() {
 
 	dialer := &net.Dialer{}
 	if conf.BindDevice != "" {
-		dialer.Control = func(network, address string, c syscall.RawConn) error {
-			return c.Control(func(fd uintptr) {
-				err := syscall.BindToDevice(int(fd), conf.BindDevice)
-				if err != nil {
-					log.Fatalln("Failed BindToDevice call:", err)
-				}
-			})
-		}
+		dialer.Control = bindToDevice(conf.BindDevice)
 	}
 
 	srv, err := socks5.New(&socks5.Config{


### PR DESCRIPTION
https://github.com/FiloSottile/captive-browser/pull/12 introduced a linux-specific constant without constraining that logic to linux, so here's a PR which fixes that 😉 

Without this patch compilation fails on darwin (and other platforms except on linux):

```
$ go get -u github.com/FiloSottile/captive-browser
# github.com/FiloSottile/captive-browser
gopath/src/github.com/FiloSottile/captive-browser/main.go:96:12: undefined: syscall.BindToDevice
```

I have _not_ tested this on Linux beyond checking that `GOOS=linux go build .` produces a binary without any errors.