### PR TITLE
doc: remove hard-coded unnecessary parameter

### DIFF
--- a/captive-browser-ubuntu-chrome.toml
+++ b/captive-browser-ubuntu-chrome.toml
@@ -20,7 +20,7 @@ browser = """
 #
 # `wlp3s0` is your network interface (eth0, wlan0 ...)
 #
-dhcp-dns = "nmcli dev show wlp3s0 | grep IP4.DNS"
+dhcp-dns = "nmcli dev show | grep IP4.DNS"
 
 # socks5-addr is the listen address for the SOCKS5 proxy server.
 socks5-addr = "localhost:1666"


### PR DESCRIPTION
on some machines, `wlp3s0` is not the right one. nmcli knows how to return the DNS value for a default interface.