### PR TITLE
Write stdout/stderr of browser to proc's stdout/stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,6 +109,8 @@ func main() {
 
 	log.Printf("Starting browser...")
 	cmd := exec.Command("/bin/sh", "-c", conf.Browser)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	cmd.Env = append(os.Environ(), "PROXY="+conf.SOCKS5Addr)
 	if err := cmd.Run(); err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
Currently, the output of the browser to execute is entirely suppressed.
But it can be helpful to find out what went wrong with the browser if it
doesn't start up properly.