### PR TITLE
[FIX]: Deprecated cli flag: --host-resolver-rules & [ADDS] flatpak chromium support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,23 +24,31 @@ cp $(go env GOPATH)/src/github.com/FiloSottile/captive-browser/captive-browser-m
 
 To disable the insecure system captive browser [see here](https://github.com/drduh/macOS-Security-and-Privacy-Guide#captive-portal). If that doesn't work, disable SIP (remember to re-enable it), and rename `/System/Library/CoreServices/Captive Network Assistant.app`.
 
-### Ubuntu
+### Linux
+
+#### Ubuntu
 
 ```
 cp $(go env GOPATH)/src/github.com/FiloSottile/captive-browser/captive-browser-ubuntu-chrome.toml ~/.config/captive-browser.toml
 ```
 
-### Arch / systemd-networkd
+#### Arch / systemd-networkd
 
 ```
 go get -u github.com/FiloSottile/captive-browser/cmd/systemd-networkd-dns
 cp $(go env GOPATH)/src/github.com/FiloSottile/captive-browser/captive-browser-arch-chrome.toml ~/.config/captive-browser.toml
 ```
 
-### Arch / dhcpcd
+#### Arch / dhcpcd
 
 ```
 cp $(go env GOPATH)/src/github.com/FiloSottile/captive-browser/captive-browser-dhcpcd-chromium.toml ~/.config/captive-browser.toml
+```
+
+#### Flatpak
+
+```
+cp $(go env GOPATH)/src/github.com/FiloSottile/captive-browser/captive-browser-flatpak-chromium.toml ~/.config/captive-browser.toml
 ```
 
 ## Usage

--- a/captive-browser-arch-chrome.toml
+++ b/captive-browser-arch-chrome.toml
@@ -9,8 +9,20 @@ browser = """
     google-chrome \
     --user-data-dir="$HOME/.google-chrome-captive" \
     --proxy-server="socks5://$PROXY" \
-    --host-resolver-rules="MAP * ~NOTFOUND , EXCLUDE localhost" \
-    --no-first-run --new-window --incognito \
+    --proxy-bypass-list="<-loopback>" \
+    --no-first-run \
+    --new-window \
+    --incognito \
+    --no-default-browser-check \
+    --no-crash-upload \
+    --disable-extensions \
+    --disable-sync \
+    --disable-background-networking \
+    --disable-client-side-phishing-detection \
+    --disable-component-update \
+    --disable-translate \
+    --disable-web-resources \
+    --safebrowsing-disable-auto-update \
     http://example.com
 """
 

--- a/captive-browser-flatpak-chromium.toml
+++ b/captive-browser-flatpak-chromium.toml
@@ -6,8 +6,8 @@
 # it maintains no state across runs. To configure this browser open a
 # normal window in it, settings will be preserved.
 browser = """
-    chromium \
-    --user-data-dir="$HOME/.chromium-captive" \
+    flatpak run org.chromium.Chromium \
+    --user-data-dir="$HOME/.google-chrome-captive" \
     --proxy-server="socks5://$PROXY" \
     --proxy-bypass-list="<-loopback>" \
     --no-first-run \
@@ -30,9 +30,9 @@ browser = """
 # DNS server address. The first match of an IPv4 regex is used.
 # IPv4 only, because let's be real, it's a captive portal.
 #
-# `wlan0` is your network interface.
+# `wlp3s0` is your network interface (eth0, wlan0 ...)
 #
-dhcp-dns = "dhcpcd -U wlan0 | grep domain_name_servers"
+dhcp-dns = "nmcli dev show | grep IP4.DNS"
 
 # socks5-addr is the listen address for the SOCKS5 proxy server.
 socks5-addr = "localhost:1666"

--- a/captive-browser-mac-chrome.toml
+++ b/captive-browser-mac-chrome.toml
@@ -9,8 +9,20 @@ browser = """
     open -n -W -a "Google Chrome" --args \
     --user-data-dir="$HOME/Library/Application Support/Google/Captive" \
     --proxy-server="socks5://$PROXY" \
-    --host-resolver-rules="MAP * ~NOTFOUND , EXCLUDE localhost" \
-    --no-first-run --new-window --incognito \
+    --proxy-bypass-list="<-loopback>" \
+    --no-first-run \
+    --new-window \
+    --incognito \
+    --no-default-browser-check \
+    --no-crash-upload \
+    --disable-extensions \
+    --disable-sync \
+    --disable-background-networking \
+    --disable-client-side-phishing-detection \
+    --disable-component-update \
+    --disable-translate \
+    --disable-web-resources \
+    --safebrowsing-disable-auto-update \
     http://example.com
 """
 

--- a/captive-browser-ubuntu-chrome.toml
+++ b/captive-browser-ubuntu-chrome.toml
@@ -9,8 +9,20 @@ browser = """
     google-chrome \
     --user-data-dir="$HOME/.google-chrome-captive" \
     --proxy-server="socks5://$PROXY" \
-    --host-resolver-rules="MAP * ~NOTFOUND , EXCLUDE localhost" \
-    --no-first-run --new-window --incognito \
+    --proxy-bypass-list="<-loopback>" \
+    --no-first-run \
+    --new-window \
+    --incognito \
+    --no-default-browser-check \
+    --no-crash-upload \
+    --disable-extensions \
+    --disable-sync \
+    --disable-background-networking \
+    --disable-client-side-phishing-detection \
+    --disable-component-update \
+    --disable-translate \
+    --disable-web-resources \
+    --safebrowsing-disable-auto-update \
     http://example.com
 """
 


### PR DESCRIPTION
This PR:
- fixes [Deprecated cli flag: --host-resolver-rules #31](https://github.com/FiloSottile/captive-browser/issues/31)
- And adds support for [Chromium installed via Flatpak](https://flathub.org/apps/org.chromium.Chromium). 