### PR TITLE
Add config for NetworkManager + Chromium + Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ cp $(go env GOPATH)/src/github.com/FiloSottile/captive-browser/captive-browser-a
 cp $(go env GOPATH)/src/github.com/FiloSottile/captive-browser/captive-browser-dhcpcd-chromium.toml ~/.config/captive-browser.toml
 ```
 
+### NetworkManager / Chromium / Wayland
+
+For Wayland compositors (Sway, Hyprland, etc.) with NetworkManager:
+
+```
+cp $(go env GOPATH)/src/github.com/FiloSottile/captive-browser/captive-browser-networkmanager-chromium-wayland.toml ~/.config/captive-browser.toml
+```
+
+Note: you may need to replace `wlan0` with your wireless interface name.
+
 ## Usage
 
 Simply run `captive-browser`, log into the captive portal, and then *quit* (⌘Q / Ctrl-Q) the Chrome instance.

--- a/captive-browser-networkmanager-chromium-wayland.toml
+++ b/captive-browser-networkmanager-chromium-wayland.toml
@@ -1,0 +1,41 @@
+# browser is the shell (/bin/sh) command executed once the proxy starts.
+# When browser exits, the proxy exits. An extra env var PROXY is available.
+#
+# Here, we use a separate Chromium instance in Incognito mode, so that
+# it can run (and be waited for) alongside the default one, and that
+# it maintains no state across runs. To configure this browser open a
+# normal window in it, settings will be preserved.
+#
+# --ozone-platform=wayland is required for Wayland compositors (Sway,
+# Hyprland, etc.) since Chromium defaults to X11 and will fail with
+# "Missing X server or $DISPLAY" without it.
+#
+# --disable-features=HttpsUpgrades prevents Chromium from upgrading
+# HTTP to HTTPS, which would break captive portal login pages.
+browser = """
+    chromium \
+    --ozone-platform=wayland \
+    --user-data-dir="$HOME/.chromium-captive" \
+    --proxy-server="socks5://$PROXY" \
+    --proxy-bypass-list="<-loopback>" \
+    --no-first-run \
+    --new-window \
+    --incognito \
+    --disable-features=HttpsUpgrades \
+    --disable-extensions \
+    --disable-sync \
+    --disable-background-networking \
+    --disable-component-update \
+    http://example.com
+"""
+
+# dhcp-dns is the shell (/bin/sh) command executed to obtain the DHCP
+# DNS server address. The first match of an IPv4 regex is used.
+# IPv4 only, because let's be real, it's a captive portal.
+#
+# Uses nmcli to get the DNS server provided by DHCP via NetworkManager.
+# Replace wlan0 with your wireless interface name if different.
+dhcp-dns = "nmcli -t -f IP4.DNS device show wlan0 | head -1 | cut -d: -f2"
+
+# socks5-addr is the listen address for the SOCKS5 proxy server.
+socks5-addr = "localhost:1666"


### PR DESCRIPTION
This pull request was vibe-coded, including the description below.  The work of reviewing and approving pull requests like this one may be much bigger than the work of creating pull requests like this one.  If you find this pull request annoying, then close it - with or without an explaination
---

## Summary

Adds an example config file (`captive-browser-networkmanager-chromium-wayland.toml`) for a common Linux setup that isn't currently covered:

- **NetworkManager** for DHCP DNS detection (via `nmcli`) — addresses #10
- **Chromium** (native package)
- **Wayland** compositors (Sway, Hyprland, etc.)

### Key differences from existing configs

| Flag | Why |
|------|-----|
| `--ozone-platform=wayland` | Required for Wayland. Without it, Chromium defaults to X11 and exits with `Missing X server or $DISPLAY` when launched from a systemd user service or headless context |
| `--proxy-bypass-list="<-loopback>"` | Replaces the deprecated `--host-resolver-rules` flag (#31) |
| `--disable-features=HttpsUpgrades` | Prevents Chromium from upgrading captive portal HTTP pages to HTTPS, which breaks login flows |
| `nmcli -t -f IP4.DNS device show wlan0` | DHCP DNS detection via NetworkManager instead of dhcpcd or systemd-networkd |

### Motivation

On modern Linux desktops, Wayland + NetworkManager is a very common combination (Fedora, Arch with Sway/Hyprland, etc.). The existing config files all assume X11 and either dhcpcd or systemd-networkd for DNS detection. Users hitting this will see Chromium crash silently with an X11 error, which is hard to diagnose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)